### PR TITLE
Fix reversed delim options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 go:
         - "1.7.x"
         - "1.8.x"
+        - "1.9.x"
         - "master"
 install:
         - go get github.com/Masterminds/glide

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type pkgWrapper struct {
 }
 
 func render(templateString string, sourcePath string, pkg *wrapgen.Package, r string, l string) (string, error) {
-	var t, e = template.New("wrapgen").Funcs(sprig.TxtFuncMap()).Delims(r, l).Parse(templateString)
+	var t, e = template.New("wrapgen").Funcs(sprig.TxtFuncMap()).Delims(l, r).Parse(templateString)
 	if e != nil {
 		return "", e
 	}
@@ -77,14 +77,14 @@ func main() {
 			Usage: "The import path of the `PACKAGE` to render",
 		},
 		cli.StringFlag{
-			Name:  "rightdelim,r",
+			Name:  "leftdelim,l",
 			Value: "#!",
-			Usage: "The right-hand-side delimiter to use when rendering a template.",
+			Usage: "The left-hand-side delimiter to use when rendering a template.",
 		},
 		cli.StringFlag{
-			Name:  "leftdelim,l",
+			Name:  "rightdelim,r",
 			Value: "!#",
-			Usage: "The left-hand-side delimiter to use when rendering a template.",
+			Usage: "The right-hand-side delimiter to use when rendering a template.",
 		},
 	}
 	app.Action = func(c *cli.Context) error {


### PR DESCRIPTION
The defaults worked with the sample templates but did not accurately
document the settings or allow for overriding. This corrects the usage
of Template.Delims to use (l,r) and corrects the default flag values
to match what they were intended to be.