### PR TITLE
Fix source package name detection

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZC
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
-github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
@@ -16,7 +14,6 @@ github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/kevinconway/wrapgen v1.0.0 h1:dvVKFZ/9Lex6gygFp1Kx8qV3FQeOiJW52jy5LRTIdfM=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
@@ -51,8 +48,6 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200922173257-82fe25c37531 h1:FS7ZiladzQ5yC5TWXke5sO9bHgSg37DItOho2WWf43U=
-golang.org/x/tools v0.0.0-20200922173257-82fe25c37531/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20200928112810-42b62fc93869 h1:6Zj8sAhgEtZaHYz4O/Grp2Gyh0FLb8a7sLJTanOG5QQ=
 golang.org/x/tools v0.0.0-20200928112810-42b62fc93869/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -57,6 +57,30 @@ func loadPackage(ctx context.Context, path string) (*packages.Package, error) {
 	return pkg, nil
 }
 
+func LoadPackage(ctx context.Context, srcPkg string, dstPkg string, names []string) (*Package, error) {
+	pkg, err := loadPackage(ctx, srcPkg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load package data: %v", err)
+	}
+	var srcPkgAlias string
+	if dstPkg != "" {
+		srcPkgAlias = "srcPkgAlias"
+	}
+	imports, interfaces, err := LoadInterfaces(ctx, srcPkg, srcPkgAlias, names)
+	if err != nil {
+		return nil, err
+	}
+	return &Package{
+		Name: pkg.Name,
+		Source: &Import{
+			Package: pkg.Name,
+			Path:    srcPkg,
+		},
+		Interfaces: interfaces,
+		Imports:    imports,
+	}, nil
+}
+
 func LoadInterfaces(ctx context.Context, srcPkg, srcPkgAlias string, names []string) ([]*Import, []*Interface, error) {
 	pkg, err := loadPackage(ctx, srcPkg)
 	if err != nil {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -11,6 +11,10 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+const (
+	sourceAlias = "srcPkgAlias"
+)
+
 func loadPackage(ctx context.Context, path string) (*packages.Package, error) {
 	fset := token.NewFileSet()
 	conf := &packages.Config{
@@ -64,21 +68,25 @@ func LoadPackage(ctx context.Context, srcPkg string, dstPkg string, names []stri
 	}
 	var srcPkgAlias string
 	if dstPkg != "" {
-		srcPkgAlias = "srcPkgAlias"
+		srcPkgAlias = sourceAlias
 	}
 	imports, interfaces, err := LoadInterfaces(ctx, srcPkg, srcPkgAlias, names)
 	if err != nil {
 		return nil, err
 	}
-	return &Package{
-		Name: pkg.Name,
+	result := &Package{
+		Name: dstPkg,
 		Source: &Import{
 			Package: pkg.Name,
 			Path:    srcPkg,
 		},
 		Interfaces: interfaces,
 		Imports:    imports,
-	}, nil
+	}
+	if result.Name == "" {
+		result.Name = pkg.Name
+	}
+	return result, nil
 }
 
 func LoadInterfaces(ctx context.Context, srcPkg, srcPkgAlias string, names []string) ([]*Import, []*Interface, error) {

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -31,6 +31,44 @@ func TestParserSuccess(t *testing.T) {
 	}
 }
 
+func TestParserSuccessCustomPackageName(t *testing.T) {
+	ctx := context.Background()
+	path := "github.com/kevinconway/wrapgen/v2/internal/test/happy"
+	names := []string{
+		"ExportedInterface",
+		"ExportedInterfaceWithEmbedded",
+		"ExportedInterfaceWithRemoteEmbedded",
+		"ExportedInterfaceWith3rdPartyEmbedded",
+		"InterfaceExtension",
+		"InterfaceAlias",
+		"RemoteInterfaceExtension",
+		"RemoteInterfaceAlias",
+		"ThirdPartyInterfaceExtension",
+		"ThirdPartyInterfaceAlias",
+		"IndirectThirdPartyInterfaceExtension",
+		"IndirectThirdPartyInterfaceAlias",
+	}
+	pkg, err := LoadPackage(ctx, path, "custom", names)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(pkg.Interfaces) < len(names) {
+		t.Fatalf("did not render all interfaces: %v", pkg.Interfaces)
+	}
+	if pkg.Name != "custom" {
+		t.Fatalf("did not use correct output package name: %s", pkg.Name)
+	}
+	found := false
+	for _, imp := range pkg.Imports {
+		if imp.Path == path && imp.Package == sourceAlias {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("did not inject a source package alias: %v", pkg.Imports)
+	}
+}
+
 func TestParserFailure(t *testing.T) {
 	testCases := []struct {
 		name  string
@@ -49,15 +87,27 @@ func TestParserFailure(t *testing.T) {
 
 func TestParserSuccessSub(t *testing.T) {
 	ctx := context.Background()
-	path := "./test/sub/happy"
+	path := "github.com/kevinconway/wrapgen/v2/internal/test/sub/happy"
 	names := []string{
 		"Demo",
 	}
-	pkg, err := LoadPackage(ctx, path, "", names)
+	pkg, err := LoadPackage(ctx, path, "happy", names)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	if len(pkg.Interfaces) < len(names) {
 		t.Fatalf("did not render all interfaces: %v", pkg.Interfaces)
+	}
+	if pkg.Name != "happy" {
+		t.Fatalf("did not use correct output package name: %s", pkg.Name)
+	}
+	found := false
+	for _, imp := range pkg.Imports {
+		if imp.Path == path && imp.Package == sourceAlias {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("did not inject a source package alias: %v", pkg.Imports)
 	}
 }

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -1,8 +1,8 @@
 package wrapgen
 
 import (
-	"testing"
 	"context"
+	"testing"
 )
 
 func TestParserSuccess(t *testing.T) {
@@ -22,26 +22,24 @@ func TestParserSuccess(t *testing.T) {
 		"IndirectThirdPartyInterfaceExtension",
 		"IndirectThirdPartyInterfaceAlias",
 	}
-	_, interfaces, err := LoadInterfaces(ctx, path, "", names)
+	pkg, err := LoadPackage(ctx, path, "", names)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if len(interfaces) < len(names) {
-		t.Fatalf("did not render all interfaces: %v", interfaces)
+	if len(pkg.Interfaces) < len(names) {
+		t.Fatalf("did not render all interfaces: %v", pkg.Interfaces)
 	}
 }
 
 func TestParserFailure(t *testing.T) {
-	testCases := []struct{
-		name string
-		path string
+	testCases := []struct {
+		name  string
+		path  string
 		names []string
-	}{
-
-	}
+	}{}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, _, err := LoadInterfaces(context.Background(), testCase.path, "", testCase.names)
+			_, err := LoadPackage(context.Background(), testCase.path, "", testCase.names)
 			if err == nil {
 				t.FailNow()
 			}
@@ -55,11 +53,11 @@ func TestParserSuccessSub(t *testing.T) {
 	names := []string{
 		"Demo",
 	}
-	_, interfaces, err := LoadInterfaces(ctx, path, "", names)
+	pkg, err := LoadPackage(ctx, path, "", names)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if len(interfaces) < len(names) {
-		t.Fatalf("did not render all interfaces: %v", interfaces)
+	if len(pkg.Interfaces) < len(names) {
+		t.Fatalf("did not render all interfaces: %v", pkg.Interfaces)
 	}
 }


### PR DESCRIPTION
The previous version assumed that the package path ended with the
package name. In cases where the package path contained invalid package
characters, like "-", the tools would generate invalid output.

The naive solution to this would be to use the `--package` flag to set
the name to something valid. However, this flag indicates that the
source and destination packages are different. This results in the
source package receiving an import alias to prevent conflicts. This
means that any package generated using `--package` that is rendered
within the file tree of `--source` also results in an invalid file.

This patch preserves all existing behaviors except that it now correctly
extracts the true package name rather than relying on the package path.